### PR TITLE
feat: enable secured Cloud Run deployment via Cloud Build

### DIFF
--- a/route-registration-tool/.dockerignore
+++ b/route-registration-tool/.dockerignore
@@ -3,3 +3,4 @@
 .playwright-mcp
 ui/node_modules
 ui/package-lock.json
+.env

--- a/route-registration-tool/README.md
+++ b/route-registration-tool/README.md
@@ -74,13 +74,54 @@ Road Selection Tool is a tool that allows you to select roads from a map and sav
 
 ## Deployment
 
-### Deploy to Google Cloud Run
+### Option 1: Secured Deployment (Recommended)
 
+#### Automated via Cloud Build
+This project includes a `cloudbuild.yaml` file to automate deployment with security best practices:
 ```bash
-gcloud run deploy route-registration-tool --project=your-google-cloud-project-id --region=us-central1 --source . --allow-unauthenticated --platform managed --service-account=your-service-account-gmail --max-instances=1 --min-instances=1
+gcloud builds submit --config cloudbuild.yaml --substitutions=_GOOGLE_API_KEY=YOUR_API_KEY .
+```
+*(Replace `YOUR_API_KEY` with your actual Google Maps API Key)*
+
+#### Manual via CLI
+```bash
+gcloud run deploy route-registration-tool \
+  --project=your-google-cloud-project-id \
+  --region=us-central1 \
+  --source . \
+  --no-allow-unauthenticated \
+  --platform managed \
+  --service-account=your-service-account-email \
+  --max-instances=1 \
+  --min-instances=0
 ```
 
-- Replace `your-google-cloud-project-id` and `your-service-account-gmail` as needed.
-- Service account needs following permissions:
-  - roles/bigquery.dataViewer
-  - roles/bigquery.jobUser
+#### Accessing the Secured Service
+Since the service is deployed with `--no-allow-unauthenticated`, you must use a proxy to access it from your local machine:
+```bash
+gcloud run services proxy route-registration-tool --region us-central1 --port 8081
+```
+Then, open your browser and navigate to: **http://localhost:8081**
+
+### Option 2: Public Access Deployment (For Demos Only)
+
+If you need the service to be publicly accessible without authentication (accessible directly via the Cloud Run URL):
+
+```bash
+gcloud run deploy route-registration-tool \
+  --project=your-google-cloud-project-id \
+  --region=us-central1 \
+  --source . \
+  --allow-unauthenticated \
+  --platform managed \
+  --service-account=your-service-account-email \
+  --max-instances=1 \
+  --min-instances=0
+```
+
+### Required Permissions
+The Service Account used for deployment needs the following roles:
+- `roles/bigquery.dataViewer`
+- `roles/bigquery.jobUser`
+- `roles/datastore.user` (if Firestore logging is enabled)
+- `roles/logging.logWriter`

--- a/route-registration-tool/cloudbuild.yaml
+++ b/route-registration-tool/cloudbuild.yaml
@@ -1,0 +1,34 @@
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/route-registration-tool', '.']
+
+  # Push the container image to Container Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/route-registration-tool']
+
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'route-registration-tool'
+      - '--image'
+      - 'gcr.io/$PROJECT_ID/route-registration-tool'
+      - '--region'
+      - 'us-central1'
+      - '--platform'
+      - 'managed'
+      - '--no-allow-unauthenticated'
+      - '--min-instances'
+      - '0'
+      - '--max-instances'
+      - '1'
+      - '--service-account'
+      - 'route-registration-sa@$PROJECT_ID.iam.gserviceaccount.com'
+      - '--set-env-vars'
+      - 'GOOGLE_API_KEY=$_GOOGLE_API_KEY,POLYGON_ROADS_API_URL=https://roads.googleapis.com/v2/roads:list,API_URL=https://roads.googleapis.com/selection/v1/projects/,VIEW_MODE=FALSE,ENABLE_FIRESTORE_LOGGING=false'
+
+images:
+  - 'gcr.io/$PROJECT_ID/route-registration-tool'


### PR DESCRIPTION
- Added cloudbuild.yaml for automated deployment with security best practices.
- Configured dedicated service account and scaling limits (0-1).
- Updated README.md with comprehensive instructions for secured vs. public deployment.
- Added documentation for accessing secured services via gcloud run services proxy.
- Updated .dockerignore to exclude local environment secrets.